### PR TITLE
include sub directory import as external

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "rollup-plugin-node-externals",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {


### PR DESCRIPTION
`import map from 'lodash/map'` with `lodash` as a dep, ends up importing the entire file, but the expectation is that it'll stay `require('lodash/map')`.

This fixes it, by adding an optional path after the module name.

also added `packagePath` option to specify a different package.json path.