### PR TITLE
Cannot find module 'builtin-modules' fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,9 +39,11 @@
     "dist": "trash dist && rollup -c && tsc src/index.ts --declaration --emitDeclarationOnly --outDir dist",
     "clean": "trash dist"
   },
+  "peerDependencies": {
+    "builtin-modules": "^3.1.0",
+  },
   "devDependencies": {
     "@wessberg/rollup-plugin-ts": "^1.1.73",
-    "builtin-modules": "^3.1.0",
     "rollup": "^1.25.2",
     "rollup-plugin-node-resolve": "^5.2.0",
     "trash": "^6.0.0",


### PR DESCRIPTION
Since this plugin using builtin-modules, we need to move that dependency into peerDependencies