### PR TITLE
(fix): eslint import/no-unresolved issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "!dist/**/*.map"
   ],
   "type": "module",
+  "main": "./dist/index.js",
   "exports": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "imports": {


### PR DESCRIPTION
Because of the missing 'main' key the eslint-plugin-import:resolver:node wasn't able to resolve the package as a directory, thus throwing import/unresolved error/warning.

Here's the link to the place in code that is failing: https://github.com/browserify/resolve/blob/fd788d94d037e32d4f4be948e2f7e15f6981f004/lib/sync.js#L180

If the main is not set, it defaults to index.js in the package's root folder, you're exporting index.js and declaration in the dist directory thus it's producing an error in the code pointed upper.