### PR TITLE
Remove order: 'pre' from resolveId

### DIFF
--- a/source/index.ts
+++ b/source/index.ts
@@ -233,7 +233,6 @@ function nodeExternals(options: ExternalsOptions = {}): Plugin {
         },
 
         resolveId: {
-            order: 'pre',
             async handler(specifier, importer, { isEntry }) {
                 if (
                     isEntry                                 // Ignore entry points (they should always be resolved)


### PR DESCRIPTION
This causes the plugin to run too early in Vite, preventing any `resolve.alias` from taking effect or for any other plugin to handle node builtins, whether `builtins` or `builtinsPrefix` is set.

For example, when you want to polyfill via alias some Node builtins, when building for both browser and Node.js.

`enforce: 'pre'` is still needed to run early enough in the Vite plugins order. Which makes `resolveId` already run in the right place in the plugin order.

For plain rollup, just place the plugin before other plugins that depend on aliases, for reference, the standard alias plugin doesn't include `order: 'pre'` as well, to allow control such control.